### PR TITLE
Fix: Refactor TouchEvent setup to remove duplicate code in onShowPres…

### DIFF
--- a/jme3-android/src/main/java/com/jme3/input/android/AndroidGestureProcessor.java
+++ b/jme3-android/src/main/java/com/jme3/input/android/AndroidGestureProcessor.java
@@ -86,20 +86,19 @@ public class AndroidGestureProcessor implements
     public void onShowPress(MotionEvent event) {
         float jmeX = touchInput.getJmeX(event.getX());
         float jmeY = touchInput.invertY(touchInput.getJmeY(event.getY()));
-        TouchEvent touchEvent = touchInput.getFreeTouchEvent();
-        touchEvent.set(TouchEvent.Type.SHOWPRESS, jmeX, jmeY, 0, 0);
-        touchEvent.setPointerId(touchInput.getPointerId(event));
-        touchEvent.setTime(event.getEventTime());
-        touchEvent.setPressure(event.getPressure());
-        touchInput.addEvent(touchEvent);
+        prepareTouchEvent(TouchEvent.Type.SHOWPRESS, event, jmeX, jmeY);
     }
 
     @Override
     public void onLongPress(MotionEvent event) {
         float jmeX = touchInput.getJmeX(event.getX());
         float jmeY = touchInput.invertY(touchInput.getJmeY(event.getY()));
+        prepareTouchEvent(TouchEvent.Type.LONGPRESSED, event, jmeX, jmeY);
+    }
+
+    private void prepareTouchEvent(TouchEvent.Type eventType, MotionEvent event, float x, float y) {
         TouchEvent touchEvent = touchInput.getFreeTouchEvent();
-        touchEvent.set(TouchEvent.Type.LONGPRESSED, jmeX, jmeY, 0, 0);
+        touchEvent.set(eventType, x, y, 0, 0);
         touchEvent.setPointerId(touchInput.getPointerId(event));
         touchEvent.setTime(event.getEventTime());
         touchEvent.setPressure(event.getPressure());


### PR DESCRIPTION
**Describe the pull request**
The code contains a repeated sequence in both "onShowPress" and "onLongPress" methods. In each, four lines are used to set up a "TouchEvent" object with shared properties, including setting the pointer ID, event time, pressure, and adding the event to "touchInput". This duplicated code represents a clone because the same actions are performed in both methods, creating redundancy and making maintenance harder if any shared property needs updating across both methods.

**Code before refactoring**

![image](https://github.com/user-attachments/assets/290e7f32-3d8a-4b21-aeef-8546cd66f686)

**Code after refactoring**

![image](https://github.com/user-attachments/assets/4c13cf08-9881-425a-8b23-d35c1cebd25f)

Link to the issue
Upstream Issue: [58](https://github.com/rilling/jmonkeyengineFall2024/issues/58)