### PR TITLE
Refactor: Remove duplicate file descriptor handling in `loadBuffer` and `loadStream` methods in NativeVorbisLoader

### DIFF
--- a/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisLoader.java
+++ b/jme3-android/src/main/java/com/jme3/audio/plugins/NativeVorbisLoader.java
@@ -46,32 +46,32 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 
 public class NativeVorbisLoader implements AssetLoader {
-    
+
     private static class VorbisInputStream extends InputStream implements SeekableStream {
 
         private final AssetFileDescriptor afd;
         private final NativeVorbisFile file;
-        
+
         public VorbisInputStream(AssetFileDescriptor afd, NativeVorbisFile file) {
             this.afd = afd;
             this.file = file;
         }
-        
+
         @Override
         public int read() throws IOException {
             return 0;
         }
-        
+
         @Override
         public int read(byte[] buf) throws IOException {
             return file.readIntoArray(buf, 0, buf.length);
         }
-        
+
         @Override
         public int read(byte[] buf, int off, int len) throws IOException {
             return file.readIntoArray(buf, off, len);
         }
-        
+
         @Override
         public long skip(long n) throws IOException {
             throw new IOException("Not supported for audio streams");
@@ -85,22 +85,22 @@ public class NativeVorbisLoader implements AssetLoader {
                 throw new RuntimeException(ex);
             }
         }
-        
+
         @Override
         public void close() throws IOException {
             file.clearResources();
             afd.close();
         }
     }
-    
+
     private static AudioBuffer loadBuffer(AssetInfo assetInfo) throws IOException {
         AndroidAssetInfo aai = (AndroidAssetInfo) assetInfo;
         AssetFileDescriptor afd = null;
         NativeVorbisFile file = null;
         try {
-            afd = aai.openFileDescriptor();
-            int fd = afd.getParcelFileDescriptor().getFd();
-            file = new NativeVorbisFile(fd, afd.getStartOffset(), afd.getLength());
+            afd = openFileDescriptor(aai);
+            file = createNativeVorbisFile(afd);
+
             ByteBuffer data = BufferUtils.createByteBuffer(file.totalBytes);
             file.readIntoBuffer(data);
             AudioBuffer ab = new AudioBuffer();
@@ -108,54 +108,67 @@ public class NativeVorbisLoader implements AssetLoader {
             ab.updateData(data);
             return ab;
         } finally {
-            if (file != null) {
-                file.clearResources();
-            }
-            if (afd != null) {
-                afd.close();
-            }
+            closeResources(afd, file);
         }
     }
-    
+
     private static AudioStream loadStream(AssetInfo assetInfo) throws IOException {
         AndroidAssetInfo aai = (AndroidAssetInfo) assetInfo;
         AssetFileDescriptor afd = null;
         NativeVorbisFile file = null;
         boolean success = false;
-        
+
         try {
-            afd = aai.openFileDescriptor();
-            int fd = afd.getParcelFileDescriptor().getFd();
-            file = new NativeVorbisFile(fd, afd.getStartOffset(), afd.getLength());
-            
+            afd = openFileDescriptor(aai);
+            file = createNativeVorbisFile(afd);
+
             AudioStream stream = new AudioStream();
             stream.setupFormat(file.channels, 16, file.sampleRate);
             stream.updateData(new VorbisInputStream(afd, file), file.duration);
-            
+
             success = true;
-            
             return stream;
         } finally {
             if (!success) {
-                if (file != null) {
-                    file.clearResources();
-                }
-                if (afd != null) {
-                    afd.close();
-                }
+                closeResources(afd, file);
             }
         }
     }
-    
+
+    // Helper method to open file descriptor
+    private static AssetFileDescriptor openFileDescriptor(AndroidAssetInfo aai) throws IOException {
+        return aai.openFileDescriptor();
+    }
+
+    // Helper method to create a NativeVorbisFile
+    private static NativeVorbisFile createNativeVorbisFile(AssetFileDescriptor afd) throws IOException {
+        int fd = afd.getParcelFileDescriptor().getFd();
+        return new NativeVorbisFile(fd, afd.getStartOffset(), afd.getLength());
+    }
+
+    // Helper method to close resources
+    private static void closeResources(AssetFileDescriptor afd, NativeVorbisFile file) {
+        if (file != null) {
+            file.clearResources();
+        }
+        if (afd != null) {
+            try {
+                afd.close();
+            } catch (IOException e) {
+                e.printStackTrace(); // handle or log exception appropriately
+            }
+        }
+    }
+
     @Override
     public Object load(AssetInfo assetInfo) throws IOException {
         AudioKey key = (AudioKey) assetInfo.getKey();
         if (!(assetInfo instanceof AndroidLocator.AndroidAssetInfo)) {
-            throw new UnsupportedOperationException("Cannot load audio files from classpath." + 
-                                                    "Place your audio files in " +
-                                                    "Android's assets directory");
+            throw new UnsupportedOperationException("Cannot load audio files from classpath." +
+                    "Place your audio files in " +
+                    "Android's assets directory");
         }
-        
+
         if (key.isStream()) {
             return loadStream(assetInfo);
         } else {


### PR DESCRIPTION
Issue: https://github.com/rilling/jmonkeyengineFall2024/issues/66

**Describe the pull request**
There is a 4-line code duplication in the `loadBuffer` method (line 100) and `loadStream` method (line 126) located in `NativeVorbisLoader.java`.  The duplicated file descriptor handling logic has been moved into helper methods (`openFileDescriptor`, `createNativeVorbisFile`, `closeResources`) to eliminate redundancy and improve maintainability.

![image](https://github.com/user-attachments/assets/173cbf9b-203f-45c0-ac3b-12183250e5f4)

**Code before refactoring**
![image](https://github.com/user-attachments/assets/e07c1da7-df74-40b9-abe8-b3ad51014493)

**Code after refactoring**
![image](https://github.com/user-attachments/assets/982ac67d-d4d8-43f7-949c-e5a54353f9aa)


