### PR TITLE
Refactor OpenGL error handling to remove code duplication

### DIFF
--- a/jme3-android/src/main/java/com/jme3/renderer/android/RendererUtil.java
+++ b/jme3-android/src/main/java/com/jme3/renderer/android/RendererUtil.java
@@ -63,6 +63,10 @@ public class RendererUtil {
      * {@link RendererUtil#ENABLE_ERROR_CHECKING}.
      */
     public static void checkGLErrorForced() {
+        checkAndThrowGLError();
+    }
+
+    private static void checkAndThrowGLError() {
         int error = GLES20.glGetError();
         if (error != 0) {
             String message = GLU.gluErrorString(error);
@@ -153,14 +157,6 @@ public class RendererUtil {
         if (!ENABLE_ERROR_CHECKING) {
             return;
         }
-        int error = GLES20.glGetError();
-        if (error != 0) {
-            String message = GLU.gluErrorString(error);
-            if (message == null) {
-                throw new RendererException("An unknown OpenGL error has occurred.");
-            } else {
-                throw new RendererException("An OpenGL error has occurred: " + message);
-            }
-        }
+        checkAndThrowGLError();
     }
 }


### PR DESCRIPTION
Describe the pull request
This pull request refactors the RendererUtil class to remove duplicated OpenGL error-checking code. A new helper method, checkAndThrowGLError, has been created to centralize error handling logic, which is now called in both checkGLError and checkGLErrorForced. This refactoring improves code maintainability without changing functionality.

Code Before Refactoring
![image](https://github.com/user-attachments/assets/aabe4885-527e-4cd6-b46f-ce96b1667f25)
![image](https://github.com/user-attachments/assets/dc62f43f-fd1b-4d42-a1ee-420dbd472a94)

Code After Refactoring
![image](https://github.com/user-attachments/assets/422bb983-f4b7-4b42-b3f6-2689d0530874)
![image](https://github.com/user-attachments/assets/9055da3f-13c1-4e76-82ff-c0af9e67ae1a)
![image](https://github.com/user-attachments/assets/6bcabd6e-bde7-499b-9279-22424ab02980)

Link to the issue 
[https://github.com/rilling/jmonkeyengineFall2024/issues/56](https://github.com/rilling/jmonkeyengineFall2024/issues/56)
