### PR TITLE
Fixed Path Traversal Vulnerability

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/system/ExtractNativeLibraries.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/ExtractNativeLibraries.java
@@ -68,6 +68,11 @@ public class ExtractNativeLibraries {
         String path = args[1].replace('/', File.separatorChar);
         File folder = new File(path);
         try {
+            File canonicalFolder = folder.getCanonicalFile();
+            if (!canonicalFolder.getPath().startsWith(folder.getAbsolutePath())) {
+                System.err.println("Invalid extraction path: Path traversal attempt detected.");
+                System.exit(2);
+            }
             if ("Windows32".equals(args[0])) {
                 NativeLibraryLoader.extractNativeLibraries(Platform.Windows32, folder);
             } else if ("Windows64".equals(args[0])) {
@@ -77,7 +82,7 @@ public class ExtractNativeLibraries {
             } else if ("Linux64".equals(args[0])) {
                 NativeLibraryLoader.extractNativeLibraries(Platform.Linux64, folder);
             } else if ("MacOSX32".equals(args[0])) {
-                NativeLibraryLoader.extractNativeLibraries(Platform.MacOSX32, folder);
+                NativeLibraryLoader.extractNativeLibraries(Platform.MacOSX32, canonicalFolder);
             } else if ("MacOSX64".equals(args[0])) {
                 NativeLibraryLoader.extractNativeLibraries(Platform.MacOSX64, folder);
             } else {

--- a/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java
@@ -43,6 +43,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.nio.file.Path;
 
 import com.jme3.util.res.Resources;
 
@@ -319,11 +320,18 @@ public final class NativeLibraryLoader {
     }
     
     public static void extractNativeLibraries(Platform platform, File targetDir) throws IOException {
+        Path trustedBaseDir = Paths.get("/trusted/extraction/directory");
+        Path targetDirPath = targetDir.toPath().normalize();
+
+        if (!targetDirPath.startsWith(trustedBaseDir)) {
+            throw new SecurityException("Unauthorized extraction attempt to directory: " + targetDir.getAbsolutePath());
+        }
+        if (!targetDir.exists()) {
+            targetDir.mkdirs();
+        }
+
         for (Map.Entry<NativeLibrary.Key, NativeLibrary> lib : nativeLibraryMap.entrySet()) {
             if (lib.getValue().getPlatform() == platform) {
-                if (!targetDir.exists()) {
-                    targetDir.mkdirs();
-                }
                 extractNativeLibrary(platform, lib.getValue().getName(), targetDir);
             }
         }


### PR DESCRIPTION
**Describe the pull request**
This pull request addresses a path traversal vulnerability in the ExtractNativeLibraries class by sanitizing the extraction path to ensure it remains within the intended directory. The fix prevents potential security risks from unsanitized user inputs in the command-line arguments.

**CVE**
https://cwe.mitre.org/data/definitions/23.html

Fix Provided
The fix involves sanitizing the user-provided extraction path in the ExtractNativeLibraries class by normalizing the path and ensuring it doesn't traverse outside the intended directory. This is achieved by resolving the canonical path and checking if the extracted path is within the target directory, mitigating the risk of path traversal attacks.

Code before refactoring

File Location: jme3-desktop/src/main/java/com/jme3/system/ExtractNativeLibraries.java

![image](https://github.com/user-attachments/assets/0a8261b6-eb11-463e-b715-a2d4013b2014)

File Location: jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java

![image](https://github.com/user-attachments/assets/1d7824c6-89aa-49bf-ad95-e7eef122f4b4)


Code after refactoring

File Location: jme3-desktop/src/main/java/com/jme3/system/ExtractNativeLibraries.java

![image](https://github.com/user-attachments/assets/0a30c1ce-7545-49e3-b27e-7f9de5c9344e)

File Location: jme3-desktop/src/main/java/com/jme3/system/NativeLibraryLoader.java

![image](https://github.com/user-attachments/assets/74f68348-8c97-4fe0-83c4-8795da89c1c4)


Link to the issue
https://github.com/rilling/jmonkeyengineFall2024/issues/124