### PR TITLE
Fix : Disabled External Entity Resolution in XML Parsing to fix Improper Restriction of XML External Entity Reference Vulnerability

### DIFF
--- a/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLImporter.java
+++ b/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLImporter.java
@@ -41,8 +41,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 /**
@@ -98,7 +100,18 @@ public class XMLImporter implements JmeImporter {
 
     public Savable load(InputStream f) throws IOException {
         try {
-            domIn = new DOMInputCapsule(DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(f), this);
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document doc = builder.parse(f);
+
+            domIn = new DOMInputCapsule(doc, this);
             return domIn.readSavable(null, null);
         } catch (SAXException | ParserConfigurationException e) {
             IOException ex = new IOException();


### PR DESCRIPTION
Issue: https://github.com/rilling/jmonkeyengineFall2024/issues/125

**Describe the Pull Request**
The XML parser was found to be vulnerable to XML External Entity (XXE) attacks, as it allows external entities and DTDs to be processed, leading to potential risks such as data exfiltration, denial-of-service (DoS), or remote code execution. This fix disables the resolution of external entities and DTDs, securing the XML parsing process.

**CVE**
[CWE-611: Improper Restriction of XML External Entity Reference](https://cwe.mitre.org/data/definitions/611.html)

**Fix Provided**
The vulnerability is fixed by securely configuring the DocumentBuilderFactory to disable external entities and DTD loading, which prevents XXE attacks. These changes restrict the parser from processing potentially dangerous external entities and ensure that the application handles XML data securely, maintaining confidentiality and integrity. By preventing external entity resolution, the fix mitigates risks like unauthorized access to sensitive files and DoS attacks.

**Code before refactoring**
![Screenshot 2024-11-29 004723](https://github.com/user-attachments/assets/27934273-9e71-441c-9696-e3ee5c49c4fc)

**Code after refactoring**
![Screenshot 2024-11-29 004630](https://github.com/user-attachments/assets/e04587df-36c4-432c-a6fe-dc0726b6c819)
